### PR TITLE
Remove jQuery dependency

### DIFF
--- a/terrain2stl.html
+++ b/terrain2stl.html
@@ -81,7 +81,7 @@
 									<div class="form-group">
 										<label class="control-label col-sm-6">Box Scaling Factor:</label>
 										<div class="col-sm-4">
-											<input name="boxScale" type="range" min="1" max="12" step="1" value="1" onchange="changeSize()">
+											<input name="boxScale" type="range" min="1" max="20" step="1" value="1" onchange="changeSize()">
 										</div>
 										<div class="col-sm-2" id="boxScaleLabel">1</div>
 									</div>

--- a/terrainServer.js
+++ b/terrainServer.js
@@ -34,14 +34,14 @@ app.post("/",function(req,res){
 
 	var fileNum  = counter;
 	var zipname  = "./stls/terrain-"+fileNum;
-	var filename = "./stls/rawmodel-"+fileNum+".stl";
+	var filename = "./stls/terrain-"+fileNum+".stl";
 
 //b.rotation=0;
 
 	var command = "./celevstl "+b.lat+" "+b.lng+" "+b.boxWidth/3+" "
 			+b.boxHeight/3+" "+b.vScale+" "+b.rotation+" "+b.waterDrop+" "
 			+b.baseHeight+" "+b.boxScale+" "+filename;
-	command += "; zip -q "+zipname+" "+filename;
+	command += "; zip --quiet --junk-paths "+zipname+" "+filename;
 
         console.log("> Request for "+b.lat+" "+b.lng);
 	startTime = Date.now()

--- a/terrainServer.js
+++ b/terrainServer.js
@@ -43,20 +43,6 @@ app.post("/",function(req,res){
 			+b.baseHeight+" "+b.boxScale+" "+filename;
 	command += "; zip -q "+zipname+" "+filename;
 
-	/*
-	var command = "./elevstl "+b.lat+" "+b.lng+" "+b.boxSize/3+" "
-			+b.boxSize/3+" "+b.vScale+" "+b.rotation+" "+b.waterDrop+" "+b.baseHeight+" "+b.boxScale+" > "+filename;
-	command += "; zip -q "+zipname+" "+filename;
-
-	var cfilename = "./stls/crawmodel-"+fileNum+".stl";
-	var czipname  = "./stls/cterrain-"+fileNum;
-
-        command += "; ./celevstl "+b.lat+" "+b.lng+" "+b.boxSize/3+" "
-                        +b.boxSize/3+" "+b.vScale+" "+b.rotation+" "+b.waterDrop+" "+b.baseHeight+" "+b.boxScale;
-	command += "; mv out.stl "+cfilename;
-        command += "; zip -q "+czipname+" "+cfilename;
-	*/
-
         console.log("> Request for "+b.lat+" "+b.lng);
 	startTime = Date.now()
 	paramLog = startTime+"\t"+b.lat+"\t"+b.lng+


### PR DESCRIPTION
This PR removes the jquery script include from `terrain2stl.html`. I realized that jQuery is only used in a couple lines of my own Terrain2STL-specific code and for an accordion animation. Both of those applications can be replaced with regular Javascript and a little CSS without too much trouble. As a side bonus, I also get to remove the `bootstrap.min.js` include! Always nice to remove some dependencies. 

The main resources I used to put this PR together were Claude Sonnet 3.7 (gave me a lot of code, which I later largely got rid of) and this [W3Schools page](https://www.w3schools.com/howto/howto_js_accordion.asp), which was a solution pretty close to what I wanted.