### PR TITLE
Remove jQuery

### DIFF
--- a/terrain2stl.html
+++ b/terrain2stl.html
@@ -14,6 +14,12 @@
 				overflow: hidden;
 				transition: max-height 0.2s ease-out;
 			}
+
+			.panel-body.shown {
+				padding: 10 18px;
+				max-height: max-content;
+				transition: max-height 0.2s ease-out;
+			}
 		</style>
 	</head>
 	<body>
@@ -40,7 +46,7 @@
 					      </h4>
 					    </div>
 					    <div id="collapseZero" class="panel-collapse" role="tabpanel" aria-labelledby="headingZero">
-					      <div class="panel-body" show>
+					      <div class="panel-body shown">
 									<h4>Northwest Corner Coordinates</h4>
 
 
@@ -217,15 +223,17 @@
 
 					document.querySelectorAll('.panel-body').forEach(function(panel) {
 						if (panel.id !== targetId.substring(1)) {
-							panel.style.maxHeight = null
+							//panel.style.maxHeight = null
+							panel.classList.remove("shown");
 						}
 					});
 
 					if (panel.style.maxHeight) {
-						panel.style.maxHeight = null;
-						panel.removeAttribute("show");
+						//panel.style.maxHeight = null;
+						panel.classList.remove("shown");
 					} else {
-						panel.style.maxHeight = panel.scrollHeight + "px";
+						//panel.style.maxHeight = panel.scrollHeight + "px";
+						panel.classList.add("shown");
 					} 
 				});
 				}

--- a/terrain2stl.html
+++ b/terrain2stl.html
@@ -9,7 +9,6 @@
 			/* Enhanced accordion styles */
 			.panel-body {
 				padding: 0 18px;
-				background-color: white;
 				max-height: 0;
 				overflow: hidden;
 				transition: max-height 0.2s ease-out;

--- a/terrain2stl.html
+++ b/terrain2stl.html
@@ -7,35 +7,12 @@
 		<!-- <script type="text/javascript" src="moonmaps.js"></script> -->
 		<style>
 			/* Enhanced accordion styles */
-			.panel-collapse {
-			max-height: 0;
-			overflow: hidden;
-			/*transition: max-height 1s ease;*/
-			display: block; /* Ensure it's always a block, just with 0 height */
-			}
-
-			.panel-collapse.show {
-			max-height: 2000px; /* Much larger value to accommodate any content */
-			overflow: visible; /* Allow content to be visible when expanded */
-			}
-
-			/* If you have deeply nested content, you might need this */
-			.panel-collapse .panel-body {
-			padding: 15px;
-			display: block;
-			}
-
-			/* Make sure collapsed panels don't show content */
-			.panel-collapse:not(.show) {
-			visibility: hidden;
-			height: 0;
-			padding: 0;
-			margin: 0;
-			}
-
-			.panel-collapse.show {
-			visibility: visible;
-			height: auto;
+			.panel-body {
+				padding: 0 18px;
+				background-color: white;
+				max-height: 0;
+				overflow: hidden;
+				transition: max-height 0.2s ease-out;
 			}
 		</style>
 	</head>
@@ -62,8 +39,8 @@
 					        </a>
 					      </h4>
 					    </div>
-					    <div id="collapseZero" class="panel-collapse collapse show" role="tabpanel" aria-labelledby="headingZero">
-					      <div class="panel-body">
+					    <div id="collapseZero" class="panel-collapse" role="tabpanel" aria-labelledby="headingZero">
+					      <div class="panel-body" show>
 									<h4>Northwest Corner Coordinates</h4>
 
 
@@ -92,7 +69,7 @@
 					        </a>
 					      </h4>
 					    </div>
-					    <div id="collapseOne" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
+					    <div id="collapseOne" class="panel-collapse" role="tabpanel" aria-labelledby="headingOne">
 					      <div class="panel-body">
 									<div class="form-group">
 										<label class="control-label col-sm-6">Box Width:</label>
@@ -142,7 +119,7 @@
 					        </a>
 					      </h4>
 					    </div>
-							<div id="collapseFive" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingFive">
+							<div id="collapseFive" class="panel-collapse" role="tabpanel" aria-labelledby="headingFive">
 					      <div class="panel-body">
 									<div class="form-group">
 										<label class="control-label col-sm-6">Water Drop (mm):</label>
@@ -170,7 +147,7 @@
 					        </a>
 					      </h4>
 					    </div>
-							<div id="collapseFour" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
+							<div id="collapseFour" class="panel-collapse" role="tabpanel" aria-labelledby="headingOne">
 					      <div class="panel-body">
 
 									<div id="inst">
@@ -219,41 +196,39 @@
 		<script>
 			// Accordion functionality
 			document.addEventListener('DOMContentLoaded', function() {
-				// Get all accordion panel headings
-				const accordionLinks = document.querySelectorAll('.panel-title a');
-				
-				// Add click event listener to each heading
-				accordionLinks.forEach(function(link) {
-					link.addEventListener('click', function(e) {
-						e.preventDefault();
-						
-						// Get the target panel
-						const targetId = this.getAttribute('data-target');
-						const targetPanel = document.querySelector(targetId);
-						
-						// If it's a multi-collapse accordion, uncomment this to close others
-						if (!this.parentElement.parentElement.parentElement.hasAttribute('aria-multiselectable') || 
-							this.parentElement.parentElement.parentElement.getAttribute('aria-multiselectable') !== 'true') {
-							// Close all other panels
-							document.querySelectorAll('.panel-collapse.show').forEach(function(panel) {
-								if (panel.id !== targetId.substring(1)) {
-									panel.classList.remove('show');
-									// Find the related link and add collapsed class
-									const relatedLink = document.querySelector(`a[data-target="#${panel.id}"]`);
-									if (relatedLink && !relatedLink.classList.contains('collapsed')) {
-										relatedLink.classList.add('collapsed');
-									}
-								}
-							});
+				var acc = document.querySelectorAll('.panel-title a');
+				var i;
+
+				for (i = 0; i < acc.length; i++) {
+				acc[i].addEventListener("click", function(e) {
+					e.preventDefault();
+					this.classList.toggle("active");
+
+					// Get the target panel
+					const targetId = this.getAttribute('data-target');
+
+					console.log(targetId);
+					console.log(document.querySelector(targetId))
+					const targetPanel = document.querySelector(targetId).children[0];
+					
+					var panel = targetPanel;
+
+					console.log(panel);
+
+					document.querySelectorAll('.panel-body').forEach(function(panel) {
+						if (panel.id !== targetId.substring(1)) {
+							panel.style.maxHeight = null
 						}
-						
-						// Toggle the target panel
-						targetPanel.classList.toggle('show');
-						
-						// Toggle the collapsed class on the link
-						this.classList.toggle('collapsed');
 					});
+
+					if (panel.style.maxHeight) {
+						panel.style.maxHeight = null;
+						panel.removeAttribute("show");
+					} else {
+						panel.style.maxHeight = panel.scrollHeight + "px";
+					} 
 				});
+				}
 			});
 		</script>
 

--- a/terrain2stl.html
+++ b/terrain2stl.html
@@ -5,8 +5,39 @@
 		<link rel="stylesheet" href="//jthatch.com/bootstrap-custom.css">
 		<script type="text/javascript" src="terrain2stl.js"></script>
 		<!-- <script type="text/javascript" src="moonmaps.js"></script> -->
-		<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.0/jquery.min.js"></script>
-		<script type="text/javascript" src="bootstrap.min.js"></script>
+		<style>
+			/* Enhanced accordion styles */
+			.panel-collapse {
+			max-height: 0;
+			overflow: hidden;
+			/*transition: max-height 1s ease;*/
+			display: block; /* Ensure it's always a block, just with 0 height */
+			}
+
+			.panel-collapse.show {
+			max-height: 2000px; /* Much larger value to accommodate any content */
+			overflow: visible; /* Allow content to be visible when expanded */
+			}
+
+			/* If you have deeply nested content, you might need this */
+			.panel-collapse .panel-body {
+			padding: 15px;
+			display: block;
+			}
+
+			/* Make sure collapsed panels don't show content */
+			.panel-collapse:not(.show) {
+			visibility: hidden;
+			height: 0;
+			padding: 0;
+			margin: 0;
+			}
+
+			.panel-collapse.show {
+			visibility: visible;
+			height: auto;
+			}
+		</style>
 	</head>
 	<body>
 		<div class="container-fluid">
@@ -26,12 +57,12 @@
 						<div class="panel panel-default">
 					    <div class="panel-heading" role="tab" id="headingOne">
 					      <h4 class="panel-title">
-					        <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseZero" aria-expanded="true" aria-controls="collapseZero">
+					        <a role="button" data-target="#collapseZero" href="#collapseZero" aria-expanded="true" aria-controls="collapseZero">
 					          Location
 					        </a>
 					      </h4>
 					    </div>
-					    <div id="collapseZero" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="headingZero">
+					    <div id="collapseZero" class="panel-collapse collapse show" role="tabpanel" aria-labelledby="headingZero">
 					      <div class="panel-body">
 									<h4>Northwest Corner Coordinates</h4>
 
@@ -56,7 +87,7 @@
 						<div class="panel panel-default">
 					    <div class="panel-heading" role="tab" id="headingOne">
 					      <h4 class="panel-title">
-					        <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
+					        <a role="button" data-target="#collapseOne" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
 					          Model Details
 					        </a>
 					      </h4>
@@ -106,7 +137,7 @@
 						<div class="panel panel-default">
 					    <div class="panel-heading" role="tab" id="headingFive">
 					      <h4 class="panel-title">
-					        <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseFive" aria-expanded="false" aria-controls="collapseFive">
+					        <a class="collapsed" role="button" data-target="#collapseFive" href="#collapseFive" aria-expanded="false" aria-controls="collapseFive">
 					          Water and Base Settings
 					        </a>
 					      </h4>
@@ -134,7 +165,7 @@
 						<div class="panel panel-default">
 					    <div class="panel-heading" role="tab" id="headingThree">
 					      <h4 class="panel-title">
-					        <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseFour" aria-expanded="false" aria-controls="collapseFour">
+					        <a class="collapsed" role="button" data-target="#collapseFour" href="#collapseFour" aria-expanded="false" aria-controls="collapseFour">
 					          Instructions
 					        </a>
 					      </h4>
@@ -185,6 +216,46 @@
 
 		</div>
 
+		<script>
+			// Accordion functionality
+			document.addEventListener('DOMContentLoaded', function() {
+				// Get all accordion panel headings
+				const accordionLinks = document.querySelectorAll('.panel-title a');
+				
+				// Add click event listener to each heading
+				accordionLinks.forEach(function(link) {
+					link.addEventListener('click', function(e) {
+						e.preventDefault();
+						
+						// Get the target panel
+						const targetId = this.getAttribute('data-target');
+						const targetPanel = document.querySelector(targetId);
+						
+						// If it's a multi-collapse accordion, uncomment this to close others
+						if (!this.parentElement.parentElement.parentElement.hasAttribute('aria-multiselectable') || 
+							this.parentElement.parentElement.parentElement.getAttribute('aria-multiselectable') !== 'true') {
+							// Close all other panels
+							document.querySelectorAll('.panel-collapse.show').forEach(function(panel) {
+								if (panel.id !== targetId.substring(1)) {
+									panel.classList.remove('show');
+									// Find the related link and add collapsed class
+									const relatedLink = document.querySelector(`a[data-target="#${panel.id}"]`);
+									if (relatedLink && !relatedLink.classList.contains('collapsed')) {
+										relatedLink.classList.add('collapsed');
+									}
+								}
+							});
+						}
+						
+						// Toggle the target panel
+						targetPanel.classList.toggle('show');
+						
+						// Toggle the collapsed class on the link
+						this.classList.toggle('collapsed');
+					});
+				});
+			});
+		</script>
 
 		<script async defer src="include-maps.js"></script>
 	</body>

--- a/terrain2stl.html
+++ b/terrain2stl.html
@@ -199,7 +199,11 @@
 		</div>
 
 		<script>
-			// Accordion functionality
+			// Accordion functionality adapted from W3Schools
+			//   https://www.w3schools.com/howto/howto_js_accordion.asp
+			// I've added some CSS to keep on panel open upon load
+			// https://keithjgrant.com/posts/2023/04/transitioning-to-height-auto/ mentions the scroll height trick
+			//   - it seems necessary for smooth height adjustments
 			document.addEventListener('DOMContentLoaded', function() {
 				var acc = document.querySelectorAll('.panel-title a');
 				var i;
@@ -211,27 +215,22 @@
 
 					// Get the target panel
 					const targetId = this.getAttribute('data-target');
-
-					console.log(targetId);
-					console.log(document.querySelector(targetId))
 					const targetPanel = document.querySelector(targetId).children[0];
 					
 					var panel = targetPanel;
 
-					console.log(panel);
-
 					document.querySelectorAll('.panel-body').forEach(function(panel) {
 						if (panel.id !== targetId.substring(1)) {
-							//panel.style.maxHeight = null
+							panel.style.maxHeight = null
 							panel.classList.remove("shown");
 						}
 					});
 
 					if (panel.style.maxHeight) {
-						//panel.style.maxHeight = null;
+						panel.style.maxHeight = null;
 						panel.classList.remove("shown");
 					} else {
-						//panel.style.maxHeight = panel.scrollHeight + "px";
+						panel.style.maxHeight = parseInt(panel.scrollHeight) + 20 + "px";
 						panel.classList.add("shown");
 					} 
 				});

--- a/terrain2stl.js
+++ b/terrain2stl.js
@@ -90,36 +90,40 @@ function initializeMap(){
 }
 
 //https://developer.mozilla.org/en-US/docs/Learn/HTML/Forms/Sending_forms_through_JavaScript#Sending_form_data
-function initializeForm(){
+function initializeForm() {
   var form = document.getElementById("paramForm");
   var downloadButton = document.getElementById("downloadbtn");
-  //var downloadLink   = document.getElementById("downloadlink");
-
-  $( "form" ).submit(function( event ) {
-    var str = $( this ).serialize();
-    //console.log( str );
-    sendData(str);
+  var genButton = document.getElementById("genButton");
+  
+  // Replace jQuery form submit handler with vanilla JS
+  form.addEventListener("submit", function(event) {
+    // Create URL-encoded form data string manually instead of jQuery serialize
+    const formData = new FormData(form);
+    const serializedData = new URLSearchParams(formData).toString();
+    
+    sendData(serializedData);
     event.preventDefault();
   });
 
-
   function sendData(str) {
-    $("#genButton").addClass("disabled");
-    $("#genButton").html("<i>Generating...</i>");
-    downloadButton.style = "visibility:hidden";
+    genButton.classList.add("disabled");
+    genButton.innerHTML = "<i>Generating...</i>";
+    
+    downloadButton.style.visibility = "hidden";
     var XHR = new XMLHttpRequest();
 
     // Define what happens on successful data submission
     XHR.addEventListener("load", function(event) {
       var modelNumber = event.target.responseText;
-      var modelName   = "stls/terrain-"+modelNumber+".zip";
+      var modelName = "stls/terrain-" + modelNumber + ".zip";
 
-      //make download button visible
-      downloadButton.style = "visibility:visible";
-      //give link the right href
+      // Make download button visible
+      downloadButton.style.visibility = "visible";
+      // Set the href attribute
       downloadButton.href = modelName;
-      $("#genButton").removeClass("disabled");
-      $("#genButton").html("Generate Model");
+      
+      genButton.classList.remove("disabled");
+      genButton.innerHTML = "Generate Model";
     });
 
     // Define what happens in case of error
@@ -128,9 +132,8 @@ function initializeForm(){
     });
 
     // Set up our request
-    XHR.open("POST", "gen",true);
+    XHR.open("POST", "gen", true);
     XHR.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
-
 
     // The data sent is what the user provided in the form
     XHR.send(str);


### PR DESCRIPTION
This PR removes the jquery script include from `terrain2stl.html`. I realized that jQuery is only used in a couple lines of my own Terrain2STL-specific code and for an accordion animation. Both of those applications can be replaced with regular Javascript and a little CSS without too much trouble. As a side bonus, I also get to remove the `bootstrap.min.js` include! Always nice to remove some dependencies. 

The main resources I used to put this PR together were Claude Sonnet 3.7 (gave me a lot of code, which I later largely got rid of) and this [W3Schools page](https://www.w3schools.com/howto/howto_js_accordion.asp), which was a solution pretty close to what I wanted.