### PR TITLE
Add doctype tag for standards mode

### DIFF
--- a/terrain2stl.html
+++ b/terrain2stl.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 	<head>
 		<title>Terrain2STL</title>
@@ -27,7 +28,7 @@
 				<h1>Terrain2STL <small>Create STL models of the surface of Earth</small></h1>
 			</div>
 			<div class="row">
-				<div class="col-md-8"><div style="height:75%" id="gmap"><center><h1><small>Map didn't load! Is the Google Maps API key correct?</small></h1></center></div></div>
+				<div class="col-md-8"><div style="height:75vh" id="gmap"><center><h1><small>Map didn't load! Is the Google Maps API key correct?</small></h1></center></div></div>
 				<div class="col-md-4" id="controlbox">
 
 					<center><h1>STL Generator</h1></center>


### PR DESCRIPTION
Adding an HTML <!DOCTYPE> declaration to the top of the page to fix this warning I get in Firefox:

<img width="771" alt="Screenshot 2025-05-19 at 8 25 57 AM" src="https://github.com/user-attachments/assets/4c3142b9-d1f9-426b-9dc0-3d76f0828480" />

After adding the doctype tag, I also had to update the map div to have a height of `75 vh`, which is 75% of the viewport height. This is a much cleaner way to set the div height than what I was doing before. My old map height of `100%` resulted in an invisible map, because in Standards mode divs have zero height, and my map div was inside another bootstrap div.

The resource I found suggested the `vh` fix was https://stackoverflow.com/a/26895944. 