### PR TITLE
Fill form from URL parameters

### DIFF
--- a/terrain2stl.js
+++ b/terrain2stl.js
@@ -141,6 +141,52 @@ function ingestURLParams(){
   });
 }
 
+// Function to generate a shareable URL with modified form parameters
+function createShareableURL() {
+  // Get the form element
+  const form = document.getElementById('paramForm');
+  if (!form) return;
+  
+  // Create a new URLSearchParams object
+  const shareParams = new URLSearchParams();
+  
+  // Get all form inputs, selects, and textareas
+  const formElements = form.querySelectorAll('input');
+  
+  // Loop through all form elements
+  formElements.forEach(function(element) {
+    // Skip buttons and submit inputs
+    if (element.type === 'button' || element.type === 'submit') return;
+    
+    // Get element name or ID
+    let paramName = element.name;
+    
+    // Skip elements without a usable identifier
+    if (!paramName) return;
+    
+    // Get current value and default value
+    const currentValue = element.value;
+    const defaultValue = element.defaultValue;
+    
+    // Only add parameter if value is different from default
+    if (currentValue !== defaultValue) {
+      shareParams.append(paramName, currentValue);
+    }
+  });
+  
+  // Build the URL
+  const url = new URL(window.location.href);
+  // Clear existing search parameters
+  url.search = '';
+  
+  // Only add the search parameters if we have any
+  if (shareParams.toString()) {
+    url.search = shareParams.toString();
+  }
+  
+  return url.href;
+}
+
 //https://developer.mozilla.org/en-US/docs/Learn/HTML/Forms/Sending_forms_through_JavaScript#Sending_form_data
 function initializeForm() {
   var form = document.getElementById("paramForm");

--- a/terrain2stl.js
+++ b/terrain2stl.js
@@ -120,8 +120,6 @@ function ingestURLParams(){
     // Try to match by name attribute first
     let paramName = element.name;
 
-    console.log(paramName)
-    
     // If no name, try id attribute (removing any prefix like 'c-')
     if (!paramName && element.id) {
     paramName = element.id.replace(/^[a-z]-/i, '');

--- a/terrain2stl.js
+++ b/terrain2stl.js
@@ -87,6 +87,60 @@ function initializeMap(){
   google.maps.event.addListener(rectangle, 'dragend', postDrag);	//call function after rect is dragged
 
   initializeForm();
+
+  ingestURLParams();
+  updateLatLng();
+  changeSize();
+  changeRotation();
+  changeVScale();
+  changeWaterDrop();
+  changeBaseHeight();
+}
+
+// set form values from any URL parameters that may be present
+function ingestURLParams(){
+  // Get URL parameters
+  const urlParams = new URLSearchParams(window.location.search);
+			
+  // Get form element
+  const form = document.getElementById('paramForm');
+  
+  // If no form is found, exit
+  if (!form) return;
+  
+  // Get all form inputs, selects, and textareas
+  // const formElements = form.querySelectorAll('input, select, textarea');
+  const formElements = form.querySelectorAll('input');
+
+  // Keep track of which update functions we'll need to call
+  const functionsToCall = new Set();
+  
+  // Loop through all form elements
+  formElements.forEach(function(element) {
+    // Try to match by name attribute first
+    let paramName = element.name;
+
+    console.log(paramName)
+    
+    // If no name, try id attribute (removing any prefix like 'c-')
+    if (!paramName && element.id) {
+    paramName = element.id.replace(/^[a-z]-/i, '');
+    }
+    
+    // Skip elements without a usable identifier
+    if (!paramName) return;
+    
+    // Check if this parameter exists in the URL
+    if (urlParams.has(paramName)) {
+    // Set the value
+    element.value = urlParams.get(paramName);
+    
+    // Trigger change event
+    const event = new Event('change');
+    element.dispatchEvent(event);
+    
+    }
+  });
 }
 
 //https://developer.mozilla.org/en-US/docs/Learn/HTML/Forms/Sending_forms_through_JavaScript#Sending_form_data


### PR DESCRIPTION
This is a feature I've been thinking about for a while and finally implemented! The idea is to let the webpage read in values for form elements from any URL parameters that might have been passed in. The result is that when the URL like 
`http://localhost:9000/terrain2stl.html?lat=39.1269&lng=-79.2618&boxWidth=360&boxHeight=360&boxScale=3&waterDrop=2` is loaded, the page will populate the input form and the map with a box of the width and height described in the URL at a location of (39.1269N, 79.2618W) and a water drop of 2, rather than the default settings the page usually loads with.

This feature will be helpful in testing, debug, and sharing models. 

There's also a function `createShareableURL()` that generates a link with URL parameters in it. For brevity, the function only includes form values that are different from their default values. This function is currently only accessible through the browser console, so for now it will only be used for testing. I'd like to find a nice way to add it as a button on the page in the future so that users can create and send these shareable links too.