### PR TITLE
Remove Google Analytics call on form submission

### DIFF
--- a/terrain2stl.html
+++ b/terrain2stl.html
@@ -34,7 +34,7 @@
 					<center><h1>STL Generator</h1></center>
 					<center><i>Now with adjustable rectangle shapes!</i></center></br>
 
-					<form id="paramForm" class="form-horizontal" action="gen" method="post" onsubmit="ga('send', 'event', 'Terrain2STL', 'Model');">
+					<form id="paramForm" class="form-horizontal" action="gen" method="post">
 
 					<div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
 						<div class="panel panel-default">


### PR DESCRIPTION
I'm moving the whole site away from Google Maps and also removing Google Analytics usages while I'm at it! This bit of Google Analytics javascript probably shouldn't have been in the Github version of the code anyway. 