### PR TITLE
Block the "enter" key on the input form

### DIFF
--- a/terrain2stl.js
+++ b/terrain2stl.js
@@ -193,7 +193,15 @@ function initializeForm() {
   var downloadButton = document.getElementById("downloadbtn");
   var genButton = document.getElementById("genButton");
   
-  // Replace jQuery form submit handler with vanilla JS
+  // block the input's form "press enter to submit form" behavior
+  form.addEventListener("keypress", (e) => {
+    var key = e.key || 0;
+    console.log(key)
+    if (key == "Enter") {
+      e.preventDefault();
+    }
+  })
+  
   form.addEventListener("submit", function(event) {
     // Create URL-encoded form data string manually instead of jQuery serialize
     const formData = new FormData(form);


### PR DESCRIPTION
Addresses #40! Hitting enter while editing the latitude and longitude inputs now no longer submits the form. This will prevent the accidental generation of some models. 

The solution I used was based on [this forum thread](https://teamtreehouse.com/community/how-to-disable-submitting-a-form-when-i-press-on-the-enter-key) and updated to get rid of some now-deprecated Javascript patterns.